### PR TITLE
KB-271 - support custom comment headers and text

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
   custom-url:
     description: Custom pages URL
     required: false
-    default: ""
+    default: pr-preview
   action:
     description: >
       Determines what this action will do when it is executed. Supported
@@ -72,6 +72,10 @@ inputs:
       all other events. `auto` is the default value.
     required: false
     default: auto
+  custom-header:
+    description: Optional custom header for PR comments
+    required: false
+    default: ""
 
 outputs:
   deployment-url:
@@ -151,7 +155,7 @@ runs:
       if: env.action == 'deploy' && env.deployment_status == 'success'
       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
       with:
-        header: pr-preview
+        header: ${{ inputs.custom-header }}
         message: "\
           [PR Preview Action]\
           (${{ github.server_url }}/${{ env.actionrepo }})
@@ -185,7 +189,7 @@ runs:
       if: env.action == 'remove' && env.deployment_status == 'success'
       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
       with:
-        header: pr-preview
+        header: ${{ inputs.custom-header }}
         message: "\
           [PR Preview Action]\
           (${{ github.server_url }}/${{ env.actionrepo }})

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,10 @@ inputs:
     description: Optional custom header for PR comments
     required: false
     default: ""
+  custom-message-suffix:
+    description: Optional string to append to the deployment comment
+    required: false
+    default: ""
 
 outputs:
   deployment-url:
@@ -165,6 +169,8 @@ runs:
 
           :rocket: Deployed preview to
           https://${{ env.pagesurl }}/${{ env.targetdir }}/
+          
+          ${{ inputs.custom-message-suffix }}
 
           on branch [`${{ inputs.preview-branch }}`](\
           ${{ github.server_url }}/${{ env.deployrepo }}\

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
   custom-url:
     description: Custom pages URL
     required: false
-    default: pr-preview
+    default: ""
   action:
     description: >
       Determines what this action will do when it is executed. Supported
@@ -75,7 +75,7 @@ inputs:
   custom-header:
     description: Optional custom header for PR comments
     required: false
-    default: ""
+    default: pr-preview
   custom-message-suffix:
     description: Optional string to append to the deployment comment
     required: false


### PR DESCRIPTION
This change adds two inputs to the action:

1. **custom-header** - allows you to set the comment header, which enables leaving multiple comments for different staging sites on the same PR.
2. **custom-message-suffix** - allows you to pass a custom block of text, which will be appended to the PR comment. This will enable us to list all changed articles in PRs.