### PR TITLE
DEVOPS-713 Use single-commit to prevent staging repo size growth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -142,13 +142,14 @@ runs:
       uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
       with:
         token: ${{ env.token }}
-        ssh-key: ${{ inputs.ssh-key }}        
+        ssh-key: ${{ inputs.ssh-key }}
         repository-name: ${{ env.deployrepo }}
         branch: ${{ inputs.preview-branch }}
         folder: ${{ inputs.source-dir }}
         target-folder: ${{ env.targetdir }}
         commit-message: Deploy preview for PR ${{ env.pr }} 🛫
-        force: false
+        single-commit: true
+        force: true
 
     - name: Expose deployment URL
       id: url
@@ -189,7 +190,8 @@ runs:
         folder: ${{ env.emptydir }}
         target-folder: ${{ env.targetdir }}
         commit-message: Remove preview for PR ${{ env.pr }} 🛬
-        force: false
+        single-commit: true
+        force: true
 
     - name: Leave a comment after removal
       if: env.action == 'remove' && env.deployment_status == 'success'


### PR DESCRIPTION
## Problem

The `knowledgebase-staging` repo's `gh-pages` branch grew to ~6.2 GB because each PR preview deploy added a new commit with a full Docusaurus build, and git history retained all previous content. The GitHub Pages runner ran out of disk space (`No space left on device`) during the `Upload artifact` step, causing all staging preview deployments to fail with 404s.

The core issue is that the `JamesIves/github-pages-deploy-action` is called with `force: false` and without `single-commit`, so every deploy appends a commit to the branch history. Over time, the accumulated history makes the repo too large for the GitHub Pages runner to check out, process, and upload.

## Changes

Switch both the **deploy** and **remove** steps to use `single-commit: true` and `force: true` on `JamesIves/github-pages-deploy-action`.

- **`single-commit: true`** — Creates an orphan commit (no parent) each time, so the branch always has exactly one commit. This prevents git history from accumulating and keeps the repo size proportional to only the currently active PR previews.
- **`force: true`** — Required because an orphan commit cannot fast-forward from the previous branch state. The force push replaces the branch with the new single commit.

### Why this is safe

The `target-folder` parameter ensures that each deploy only modifies its specific PR directory (e.g., `{hash}/pr-1347`). The orphan commit still contains the **full branch tree** — all other PR preview directories are preserved. Only the git history is discarded.

The risk with force push is concurrent deploys racing: if PR A and PR B both fetch `gh-pages`, make changes, and force push, the second push would overwrite the first's changes. This is mitigated by the companion PR which serializes all deploys via a shared concurrency group.

## Prerequisite

https://github.com/datagrail/knowledgebase-source/pull/1347 — Adds a shared `staging-gh-pages` concurrency group between the `deploy-staging` and `staging-cleanup` workflows, serializing all writes to the `gh-pages` branch. **That PR must be merged first** before this change is safe to deploy.

## Test plan

- [ ] Deploy a PR preview and verify the staging URL works
- [ ] Deploy a second PR preview and verify both URLs work (first PR's directory is preserved)
- [ ] Close a PR and verify the remove step cleans up correctly
- [ ] Verify `gh-pages` branch has only a single commit after each deploy
- [ ] Verify knowledgebase-staging repo size decreases after several deploys